### PR TITLE
Wait longer after wakeup

### DIFF
--- a/adafruit_am2320.py
+++ b/adafruit_am2320.py
@@ -119,7 +119,7 @@ class AM2320:
                     time.sleep(0.1)  # wait 100ms
                     break
                 except OSError:
-                    write_success = False
+                    pass
             if not write_success:
                 raise RuntimeError("Failed to wakeup I2C device")
 
@@ -136,7 +136,7 @@ class AM2320:
                     time.sleep(0.005)
                     break
                 except OSError:
-                    write_success = False
+                    pass
             if not write_success:
                 raise RuntimeError("Failed to read from I2C device")
 

--- a/adafruit_am2320.py
+++ b/adafruit_am2320.py
@@ -115,7 +115,7 @@ class AM2320:
                 i2c.write(bytes([0x00]))
             except OSError:
                 pass
-            time.sleep(0.01)  # wait 10 ms
+            time.sleep(0.1)  # wait 100 ms
 
             # Send command to read register
             cmd = [AM2320_CMD_READREG, register & 0xFF, length]

--- a/adafruit_am2320.py
+++ b/adafruit_am2320.py
@@ -110,17 +110,36 @@ class AM2320:
 
     def _read_register(self, register: int, length: int) -> bytearray:
         with self._i2c as i2c:
+            write_success = False
             # wake up sensor
-            try:
-                i2c.write(bytes([0x00]))
-            except OSError:
-                pass
-            time.sleep(0.1)  # wait 100 ms
+            for _ in range(3):
+                try:
+                    i2c.write(bytes([0x00]))
+                    write_success = True
+                    time.sleep(0.1)  # wait 100ms
+                    break
+                except OSError:
+                    write_success = False
+            if not write_success:
+                raise RuntimeError("Failed to wakeup I2C device")
+
+            time.sleep(0.01)  # wait 10 ms
 
             # Send command to read register
             cmd = [AM2320_CMD_READREG, register & 0xFF, length]
             # print("cmd: %s" % [hex(i) for i in cmd])
-            i2c.write(bytes(cmd))
+            write_success = False
+            for _ in range(3):
+                try:
+                    i2c.write(bytes(cmd))
+                    write_success = True
+                    time.sleep(0.005)
+                    break
+                except OSError:
+                    write_success = False
+            if not write_success:
+                raise RuntimeError("Failed to read from I2C device")
+
             time.sleep(0.002)  # wait 2 ms for reply
             result = bytearray(length + 4)  # 2 bytes pre, 2 bytes crc
             i2c.readinto(result)


### PR DESCRIPTION
Intended to resolve #27 

Updates the wait time after sending the wakeup command to 100ms which matches the current version of the arduino driver: https://github.com/adafruit/Adafruit_AM2320/blob/master/Adafruit_AM2320.cpp#L138

If I understand correctly it's not really possible to do the for loop retry logic which was added to the arduino driver here because our `i2c.write()` does not return a success flag to check for knowing when to loop. If I am mistaken and there is a way to do that and someone can point me in that direction I can update this with similar logic.